### PR TITLE
add -langversion:7.3 to C# templates

### DIFF
--- a/CSharp/ClientServer-NetCore/ProjectTemplate.csproj
+++ b/CSharp/ClientServer-NetCore/ProjectTemplate.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$aspnetcoreversion$</TargetFramework>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,7 +12,7 @@
 
   <ItemGroup>
     $if$ ($visualstudioversion$ < 16.0)<PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.8" />
-    $endif$<PackageReference Include="WebSharper" Version="4.6.6.407" />    
+    $endif$<PackageReference Include="WebSharper" Version="4.6.6.407" />
     <PackageReference Include="WebSharper.CSharp" Version="4.6.6.407" />
     <PackageReference Include="WebSharper.UI" Version="4.6.3.219" />
     <PackageReference Include="WebSharper.UI.CSharp" Version="4.6.3.219" />

--- a/CSharp/ClientServer/ProjectTemplate.csproj
+++ b/CSharp/ClientServer/ProjectTemplate.csproj
@@ -23,6 +23,7 @@
     <UseGlobalApplicationHostFile />
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -80,7 +81,7 @@
     </ItemGroup>
   </Target>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/CSharp/Library-NetCore/ProjectTemplate.csproj
+++ b/CSharp/Library-NetCore/ProjectTemplate.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -9,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="WebSharper" Version="4.6.6.407" />    
+    <PackageReference Include="WebSharper" Version="4.6.6.407" />
     <PackageReference Include="WebSharper.CSharp" Version="4.6.6.407" />
   </ItemGroup>
 

--- a/CSharp/Library/ProjectTemplate.csproj
+++ b/CSharp/Library/ProjectTemplate.csproj
@@ -14,6 +14,7 @@
     <TargetFrameworkVersion>v$targetframeworkversion$</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -47,7 +48,7 @@
     <Compile Include="Class1.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/CSharp/Offline-NetCore/ProjectTemplate.csproj
+++ b/CSharp/Offline-NetCore/ProjectTemplate.csproj
@@ -5,6 +5,7 @@
     <StartAction>Program</StartAction>
     <StartProgram>$([System.Environment]::GetEnvironmentVariable(`WinDir`))\explorer.exe</StartProgram>
     <StartArguments>$(MSBuildThisFileDirectory)bin\html</StartArguments>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="WebSharper" Version="4.6.6.407" />    
+    <PackageReference Include="WebSharper" Version="4.6.6.407" />
     <PackageReference Include="WebSharper.CSharp" Version="4.6.6.407" />
     <PackageReference Include="WebSharper.UI" Version="4.6.3.219" />
     <PackageReference Include="WebSharper.UI.CSharp" Version="4.6.3.219" />

--- a/CSharp/Offline/ProjectTemplate.csproj
+++ b/CSharp/Offline/ProjectTemplate.csproj
@@ -18,6 +18,7 @@
     <StartAction>Program</StartAction>
     <StartProgram>$([System.Environment]::GetEnvironmentVariable(`WinDir`))\explorer.exe</StartProgram>
     <StartArguments>$(WebSharperHtmlDirectory)</StartArguments>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -52,7 +53,7 @@
     <None Include="wsconfig.json" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/CSharp/Proxy-NetCore/ProjectTemplate.csproj
+++ b/CSharp/Proxy-NetCore/ProjectTemplate.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <WebSharperProject>Library</WebSharperProject>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="WebSharper" Version="4.6.6.407" />    
+    <PackageReference Include="WebSharper" Version="4.6.6.407" />
     <PackageReference Include="WebSharper.CSharp" Version="4.6.6.407" />
   </ItemGroup>
 

--- a/CSharp/SPA-NetCore/ProjectTemplate.csproj
+++ b/CSharp/SPA-NetCore/ProjectTemplate.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$aspnetcoreversion$</TargetFramework>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -10,7 +11,7 @@
 
   <ItemGroup>
     $if$ ($visualstudioversion$ < 16.0)<PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.8" />
-    $endif$<PackageReference Include="WebSharper" Version="4.6.6.407" />    
+    $endif$<PackageReference Include="WebSharper" Version="4.6.6.407" />
     <PackageReference Include="WebSharper.CSharp" Version="4.6.6.407" />
     <PackageReference Include="WebSharper.UI" Version="4.6.3.219" />
     <PackageReference Include="WebSharper.UI.CSharp" Version="4.6.3.219" />

--- a/CSharp/SPA/ProjectTemplate.csproj
+++ b/CSharp/SPA/ProjectTemplate.csproj
@@ -21,6 +21,7 @@
     <IISExpressAnonymousAuthentication />
     <IISExpressWindowsAuthentication />
     <IISExpressUseClassicPipelineMode />
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -73,7 +74,7 @@
     </ItemGroup>
   </Target>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>


### PR DESCRIPTION
Prevent the use of C# language features that the transpiler does not (yet) support.  
Using such features (such as the ??= operator) leads to confusing compiler errors.  
This should be updated/removed, as the transpiler is updated further.

